### PR TITLE
feat: Add Zaelot UI polish and branding enhancements

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
@@ -250,7 +250,7 @@ function createCopilotSetupStep(id: string, button: string, when: string, includ
 		description,
 		when: `${when} && !chatSetupHidden`,
 		media: {
-			type: 'svg', altText: 'VS Code Copilot multi file edits', path: 'multi-file-edits.svg'
+			type: 'svg', altText: 'Zaelot Developer Studio Copilot multi file edits', path: 'multi-file-edits.svg'
 		},
 	};
 }
@@ -258,12 +258,12 @@ function createCopilotSetupStep(id: string, button: string, when: string, includ
 export const walkthroughs: GettingStartedWalkthroughContent = [
 	{
 		id: 'Setup',
-		title: localize('gettingStarted.setup.title', "Get started with VS Code"),
-		description: localize('gettingStarted.setup.description', "Customize your editor, learn the basics, and start coding"),
+		title: localize('gettingStarted.setup.title', "Get started with Zaelot Developer Studio"),
+		description: localize('gettingStarted.setup.description', "Set up your AI-powered development environment with Claude integration"),
 		isFeatured: true,
 		icon: setupIcon,
 		when: '!isWeb',
-		walkthroughPageTitle: localize('gettingStarted.setup.walkthroughPageTitle', 'Setup VS Code'),
+		walkthroughPageTitle: localize('gettingStarted.setup.walkthroughPageTitle', 'Setup Zaelot Developer Studio'),
 		next: 'Beginner',
 		content: {
 			type: 'steps',
@@ -284,10 +284,10 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 				{
 					id: 'extensionsWeb',
 					title: localize('gettingStarted.extensions.title', "Code with extensions"),
-					description: localize('gettingStarted.extensionsWeb.description.interpolated', "Extensions are VS Code's power-ups. A growing number are becoming available in the web.\n{0}", Button(localize('browsePopularWeb', "Browse Popular Web Extensions"), 'command:workbench.extensions.action.showPopularExtensions')),
+					description: localize('gettingStarted.extensionsWeb.description.interpolated', "Extensions are Zaelot Developer Studio's power-ups. A growing number are becoming available in the web.\n{0}", Button(localize('browsePopularWeb', "Browse Popular Web Extensions"), 'command:workbench.extensions.action.showPopularExtensions')),
 					when: 'workspacePlatform == \'webworker\'',
 					media: {
-						type: 'svg', altText: 'VS Code extension marketplace with featured language extensions', path: 'extensions-web.svg'
+						type: 'svg', altText: 'Zaelot Developer Studio extension marketplace with featured language extensions', path: 'extensions-web.svg'
 					},
 				},
 				{
@@ -303,9 +303,9 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 				// {
 				// 	id: 'settings',
 				// 	title: localize('gettingStarted.settings.title', "Tune your settings"),
-				// 	description: localize('gettingStarted.settings.description.interpolated', "Customize every aspect of VS Code and your extensions to your liking. Commonly used settings are listed first to get you started.\n{0}", Button(localize('tweakSettings', "Open Settings"), 'command:toSide:workbench.action.openSettings')),
+				// 	description: localize('gettingStarted.settings.description.interpolated', "Customize every aspect of Zaelot Developer Studio and your extensions to your liking. Commonly used settings are listed first to get you started.\n{0}", Button(localize('tweakSettings', "Open Settings"), 'command:toSide:workbench.action.openSettings')),
 				// 	media: {
-				// 		type: 'svg', altText: 'VS Code Settings', path: 'settings.svg'
+				// 		type: 'svg', altText: 'Zaelot Developer Studio Settings', path: 'settings.svg'
 				// 	},
 				// },
 				// {
@@ -321,24 +321,24 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 				{
 					id: 'settingsAndSync',
 					title: localize('gettingStarted.settings.title', "Tune your settings"),
-					description: localize('gettingStarted.settingsAndSync.description.interpolated', "Customize every aspect of VS Code and your extensions to your liking. [Back up and sync](command:workbench.userDataSync.actions.turnOn) your essential customizations across all your devices.\n{0}", Button(localize('tweakSettings', "Open Settings"), 'command:toSide:workbench.action.openSettings')),
+					description: localize('gettingStarted.settingsAndSync.description.interpolated', "Customize every aspect of Zaelot Developer Studio and your extensions to your liking. [Back up and sync](command:workbench.userDataSync.actions.turnOn) your essential customizations across all your devices.\n{0}", Button(localize('tweakSettings', "Open Settings"), 'command:toSide:workbench.action.openSettings')),
 					when: 'syncStatus != uninitialized',
 					completionEvents: ['onEvent:sync-enabled'],
 					media: {
-						type: 'svg', altText: 'VS Code Settings', path: 'settings.svg'
+						type: 'svg', altText: 'Zaelot Developer Studio Settings', path: 'settings.svg'
 					},
 				},
 				{
 					id: 'commandPaletteTask',
 					title: localize('gettingStarted.commandPalette.title', "Unlock productivity with the Command Palette "),
-					description: localize('gettingStarted.commandPalette.description.interpolated', "Run commands without reaching for your mouse to accomplish any task in VS Code.\n{0}", Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommands')),
+					description: localize('gettingStarted.commandPalette.description.interpolated', "Run commands without reaching for your mouse to accomplish any task in Zaelot Developer Studio.\n{0}", Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommands')),
 					media: { type: 'svg', altText: 'Command Palette overlay for searching and executing commands.', path: 'commandPalette.svg' },
 				},
 				// Hidden in favor of copilot entry (to be revisited when copilot entry moves, if at all)
 				// {
 				// 	id: 'pickAFolderTask-Mac',
 				// 	title: localize('gettingStarted.setup.OpenFolder.title', "Open up your code"),
-				// 	description: localize('gettingStarted.setup.OpenFolder.description.interpolated', "You're all set to start coding. Open a project folder to get your files into VS Code.\n{0}", Button(localize('pickFolder', "Pick a Folder"), 'command:workbench.action.files.openFileFolder')),
+				// 	description: localize('gettingStarted.setup.OpenFolder.description.interpolated', "You're all set to start coding. Open a project folder to get your files into Zaelot Developer Studio.\n{0}", Button(localize('pickFolder', "Pick a Folder"), 'command:workbench.action.files.openFileFolder')),
 				// 	when: 'isMac && workspaceFolderCount == 0',
 				// 	media: {
 				// 		type: 'svg', altText: 'Explorer view showing buttons for opening folder and cloning repository.', path: 'openFolder.svg'
@@ -347,7 +347,7 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 				// {
 				// 	id: 'pickAFolderTask-Other',
 				// 	title: localize('gettingStarted.setup.OpenFolder.title', "Open up your code"),
-				// 	description: localize('gettingStarted.setup.OpenFolder.description.interpolated', "You're all set to start coding. Open a project folder to get your files into VS Code.\n{0}", Button(localize('pickFolder', "Pick a Folder"), 'command:workbench.action.files.openFolder')),
+				// 	description: localize('gettingStarted.setup.OpenFolder.description.interpolated', "You're all set to start coding. Open a project folder to get your files into Zaelot Developer Studio.\n{0}", Button(localize('pickFolder', "Pick a Folder"), 'command:workbench.action.files.openFolder')),
 				// 	when: '!isMac && workspaceFolderCount == 0',
 				// 	media: {
 				// 		type: 'svg', altText: 'Explorer view showing buttons for opening folder and cloning repository.', path: 'openFolder.svg'
@@ -365,8 +365,8 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 				{
 					id: 'videoTutorial',
 					title: localize('gettingStarted.videoTutorial.title', "Watch video tutorials"),
-					description: localize('gettingStarted.videoTutorial.description.interpolated', "Watch the first in a series of short & practical video tutorials for VS Code's key features.\n{0}", Button(localize('watch', "Watch Tutorial"), 'https://aka.ms/vscode-getting-started-video')),
-					media: { type: 'svg', altText: 'VS Code Settings', path: 'learn.svg' },
+					description: localize('gettingStarted.videoTutorial.description.interpolated', "Watch the first in a series of short & practical video tutorials for Zaelot Developer Studio's key features.\n{0}", Button(localize('watch', "Watch Tutorial"), 'https://aka.ms/vscode-getting-started-video')),
+					media: { type: 'svg', altText: 'Zaelot Developer Studio Settings', path: 'learn.svg' },
 				}
 			]
 		}
@@ -374,13 +374,13 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 
 	{
 		id: 'SetupWeb',
-		title: localize('gettingStarted.setupWeb.title', "Get Started with VS Code for the Web"),
+		title: localize('gettingStarted.setupWeb.title', "Get Started with Zaelot Developer Studio for the Web"),
 		description: localize('gettingStarted.setupWeb.description', "Customize your editor, learn the basics, and start coding"),
 		isFeatured: true,
 		icon: setupIcon,
 		when: 'isWeb',
 		next: 'Beginner',
-		walkthroughPageTitle: localize('gettingStarted.setupWeb.walkthroughPageTitle', 'Setup VS Code Web'),
+		walkthroughPageTitle: localize('gettingStarted.setupWeb.walkthroughPageTitle', 'Setup Zaelot Developer Studio Web'),
 		content: {
 			type: 'steps',
 			steps: [
@@ -406,10 +406,10 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 				{
 					id: 'extensionsWebWeb',
 					title: localize('gettingStarted.extensions.title', "Code with extensions"),
-					description: localize('gettingStarted.extensionsWeb.description.interpolated', "Extensions are VS Code's power-ups. A growing number are becoming available in the web.\n{0}", Button(localize('browsePopularWeb', "Browse Popular Web Extensions"), 'command:workbench.extensions.action.showPopularExtensions')),
+					description: localize('gettingStarted.extensionsWeb.description.interpolated', "Extensions are Zaelot Developer Studio's power-ups. A growing number are becoming available in the web.\n{0}", Button(localize('browsePopularWeb', "Browse Popular Web Extensions"), 'command:workbench.extensions.action.showPopularExtensions')),
 					when: 'workspacePlatform == \'webworker\'',
 					media: {
-						type: 'svg', altText: 'VS Code extension marketplace with featured language extensions', path: 'extensions-web.svg'
+						type: 'svg', altText: 'Zaelot Developer Studio extension marketplace with featured language extensions', path: 'extensions-web.svg'
 					},
 				},
 				{
@@ -434,13 +434,13 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 				{
 					id: 'commandPaletteTaskWeb',
 					title: localize('gettingStarted.commandPalette.title', "Unlock productivity with the Command Palette "),
-					description: localize('gettingStarted.commandPalette.description.interpolated', "Run commands without reaching for your mouse to accomplish any task in VS Code.\n{0}", Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommands')),
+					description: localize('gettingStarted.commandPalette.description.interpolated', "Run commands without reaching for your mouse to accomplish any task in Zaelot Developer Studio.\n{0}", Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommands')),
 					media: { type: 'svg', altText: 'Command Palette overlay for searching and executing commands.', path: 'commandPalette.svg' },
 				},
 				{
 					id: 'pickAFolderTask-WebWeb',
 					title: localize('gettingStarted.setup.OpenFolder.title', "Open up your code"),
-					description: localize('gettingStarted.setup.OpenFolderWeb.description.interpolated', "You're all set to start coding. You can open a local project or a remote repository to get your files into VS Code.\n{0}\n{1}", Button(localize('openFolder', "Open Folder"), 'command:workbench.action.addRootFolder'), Button(localize('openRepository', "Open Repository"), 'command:remoteHub.openRepository')),
+					description: localize('gettingStarted.setup.OpenFolderWeb.description.interpolated', "You're all set to start coding. You can open a local project or a remote repository to get your files into Zaelot Developer Studio.\n{0}\n{1}", Button(localize('openFolder', "Open Folder"), 'command:workbench.action.addRootFolder'), Button(localize('openRepository', "Open Repository"), 'command:remoteHub.openRepository')),
 					when: 'workspaceFolderCount == 0',
 					media: {
 						type: 'svg', altText: 'Explorer view showing buttons for opening folder and cloning repository.', path: 'openFolder.svg'
@@ -461,12 +461,12 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 	{
 		id: 'SetupAccessibility',
 		title: localize('gettingStarted.setupAccessibility.title', "Get Started with Accessibility Features"),
-		description: localize('gettingStarted.setupAccessibility.description', "Learn the tools and shortcuts that make VS Code accessible. Note that some actions are not actionable from within the context of the walkthrough."),
+		description: localize('gettingStarted.setupAccessibility.description', "Learn the tools and shortcuts that make Zaelot Developer Studio accessible. Note that some actions are not actionable from within the context of the walkthrough."),
 		isFeatured: true,
 		icon: setupIcon,
 		when: CONTEXT_ACCESSIBILITY_MODE_ENABLED.key,
 		next: 'Setup',
-		walkthroughPageTitle: localize('gettingStarted.setupAccessibility.walkthroughPageTitle', 'Setup VS Code Accessibility'),
+		walkthroughPageTitle: localize('gettingStarted.setupAccessibility.walkthroughPageTitle', 'Setup Zaelot Developer Studio Accessibility'),
 		content: {
 			type: 'steps',
 			steps: [
@@ -497,7 +497,7 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 				{
 					id: 'commandPaletteTaskAccessibility',
 					title: localize('gettingStarted.commandPaletteAccessibility.title', "Unlock productivity with the Command Palette "),
-					description: localize('gettingStarted.commandPaletteAccessibility.description.interpolated', "Run commands without reaching for your mouse to accomplish any task in VS Code.\n{0}", Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommands')),
+					description: localize('gettingStarted.commandPaletteAccessibility.description.interpolated', "Run commands without reaching for your mouse to accomplish any task in Zaelot Developer Studio.\n{0}", Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommands')),
 					media: { type: 'markdown', path: 'empty' },
 				},
 				{
@@ -570,10 +570,10 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 				{
 					id: 'extensions',
 					title: localize('gettingStarted.extensions.title', "Code with extensions"),
-					description: localize('gettingStarted.extensions.description.interpolated', "Extensions are VS Code's power-ups. They range from handy productivity hacks, expanding out-of-the-box features, to adding completely new capabilities.\n{0}", Button(localize('browsePopular', "Browse Popular Extensions"), 'command:workbench.extensions.action.showPopularExtensions')),
+					description: localize('gettingStarted.extensions.description.interpolated', "Extensions are Zaelot Developer Studio's power-ups. They range from handy productivity hacks, expanding out-of-the-box features, to adding completely new capabilities.\n{0}", Button(localize('browsePopular', "Browse Popular Extensions"), 'command:workbench.extensions.action.showPopularExtensions')),
 					when: 'workspacePlatform != \'webworker\'',
 					media: {
-						type: 'svg', altText: 'VS Code extension marketplace with featured language extensions', path: 'extensions.svg'
+						type: 'svg', altText: 'Zaelot Developer Studio extension marketplace with featured language extensions', path: 'extensions.svg'
 					},
 				},
 				{
@@ -703,7 +703,7 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 					title: localize('gettingStarted.agentMode.title', "Agent mode"),
 					description: localize('gettingStarted.agentMode.description', "Analyzes the problem, plans next steps, and makes changes for you."),
 					media: {
-						type: 'svg', altText: 'VS Code Copilot multi file edits', path: 'multi-file-edits.svg'
+						type: 'svg', altText: 'Zaelot Developer Studio Copilot multi file edits', path: 'multi-file-edits.svg'
 					},
 				},
 				{
@@ -733,7 +733,7 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
 				{
 					id: 'newCommandPaletteTask',
 					title: localize('newgettingStarted.commandPalette.title', "All commands within reach"),
-					description: localize('gettingStarted.commandPalette.description.interpolated', "Run commands without reaching for your mouse to accomplish any task in VS Code.\n{0}", Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommands')),
+					description: localize('gettingStarted.commandPalette.description.interpolated', "Run commands without reaching for your mouse to accomplish any task in Zaelot Developer Studio.\n{0}", Button(localize('commandPalette', "Open Command Palette"), 'command:workbench.action.showCommands')),
 					media: { type: 'svg', altText: 'Command Palette overlay for searching and executing commands.', path: 'commandPalette.svg' },
 				},
 				{

--- a/src/vs/workbench/contrib/zaelot/browser/media/zaelot.css
+++ b/src/vs/workbench/contrib/zaelot/browser/media/zaelot.css
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/* Zaelot Developer Studio Branding */
+
+.zaelot-welcome-header {
+	display: flex;
+	align-items: center;
+	margin-bottom: 20px;
+	padding-bottom: 15px;
+	border-bottom: 2px solid #007ACC;
+}
+
+.zaelot-logo {
+	width: 48px;
+	height: 48px;
+	margin-right: 15px;
+	background: #007ACC;
+	border-radius: 6px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: white;
+	font-weight: bold;
+	font-size: 20px;
+}
+
+.zaelot-welcome-title {
+	font-size: 24px;
+	font-weight: 600;
+	color: #007ACC;
+	margin: 0;
+}
+
+.zaelot-welcome-subtitle {
+	font-size: 14px;
+	color: var(--vscode-foreground);
+	margin: 5px 0 0 0;
+	opacity: 0.8;
+}
+
+.zaelot-button {
+	background: #007ACC;
+	color: #FFFFFF;
+	border: none;
+	border-radius: 6px;
+	padding: 8px 16px;
+	font-weight: 500;
+	cursor: pointer;
+	transition: background-color 0.2s ease;
+}
+
+.zaelot-button:hover {
+	background: #0E4B7A;
+}
+
+.gettingStartedContainer .zaelot-branding {
+	text-align: center;
+	padding: 20px;
+	background: linear-gradient(135deg, #007ACC, #0E4B7A);
+	color: white;
+	border-radius: 8px;
+	margin-bottom: 20px;
+}
+
+.gettingStartedContainer .zaelot-branding h1 {
+	margin: 0;
+	font-size: 28px;
+	font-weight: 600;
+}
+
+.gettingStartedContainer .zaelot-branding p {
+	margin: 8px 0 0 0;
+	opacity: 0.9;
+	font-size: 14px;
+}

--- a/src/vs/workbench/contrib/zaelot/browser/zaelot.contribution.ts
+++ b/src/vs/workbench/contrib/zaelot/browser/zaelot.contribution.ts
@@ -1,0 +1,144 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Registry } from '../../../../platform/registry/common/platform.js';
+import { IWorkbenchContribution, IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from '../../../common/contributions.js';
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { IThemeService } from '../../../../platform/theme/common/themeService.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { IWorkbenchLayoutService } from '../../../services/layout/browser/layoutService.js';
+import { ILifecycleService, LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
+import { ZaelotSplashService } from './zaelotSplash.js';
+import { mainWindow } from '../../../../base/browser/window.js';
+
+// Import theme colors
+import './zaelotTheme.js';
+
+class ZaelotWorkbenchContribution extends Disposable implements IWorkbenchContribution {
+
+	constructor(
+		@IThemeService private readonly themeService: IThemeService,
+		@ILogService private readonly logService: ILogService,
+		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
+		@ILifecycleService private readonly lifecycleService: ILifecycleService
+	) {
+		super();
+
+		this._initialize();
+	}
+
+	private _initialize(): void {
+		this.logService.info('Zaelot Developer Studio theme and styling initialized');
+
+		// Initialize splash screen
+		this._register(new ZaelotSplashService(
+			this.themeService,
+			this.layoutService,
+			this.lifecycleService,
+			this.logService
+		));
+
+		// Apply Zaelot branding enhancements
+		this._applyZaelotStyling();
+
+		// Listen for theme changes
+		this._register(this.themeService.onDidColorThemeChange(() => {
+			this._applyZaelotStyling();
+		}));
+	}
+
+	private _applyZaelotStyling(): void {
+		// Add Zaelot-specific CSS classes to the body
+		const body = mainWindow.document.body;
+
+		if (!body.classList.contains('zaelot-studio')) {
+			body.classList.add('zaelot-studio');
+		}
+
+		// Add theme-specific classes
+		const currentTheme = this.themeService.getColorTheme();
+		const isDark = currentTheme.type === 'dark';
+
+		body.classList.toggle('zaelot-dark', isDark);
+		body.classList.toggle('zaelot-light', !isDark);
+
+		// Apply custom styling to welcome page if it exists
+		this._enhanceWelcomePage();
+
+		// Apply custom styling to activity bar
+		this._enhanceActivityBar();
+
+		// Apply custom styling to status bar
+		this._enhanceStatusBar();
+	}
+
+	private _enhanceWelcomePage(): void {
+		// Find welcome page container
+		const welcomeContainer = mainWindow.document.querySelector('.gettingStartedContainer');
+		if (welcomeContainer && !welcomeContainer.classList.contains('zaelot-enhanced')) {
+			welcomeContainer.classList.add('zaelot-enhanced');
+
+			// Add Zaelot branding to welcome page
+			const brandingDiv = mainWindow.document.createElement('div');
+			brandingDiv.className = 'zaelot-branding';
+			brandingDiv.innerHTML = `
+				<div class="zaelot-welcome-header">
+					<div class="zaelot-logo">Z</div>
+					<div>
+						<h1 class="zaelot-welcome-title">Zaelot Developer Studio</h1>
+						<p class="zaelot-welcome-subtitle">Powered by Claude AI</p>
+					</div>
+				</div>
+			`;
+
+			// Insert at the beginning of welcome container
+			welcomeContainer.insertBefore(brandingDiv, welcomeContainer.firstChild);
+		}
+	}
+
+	private _enhanceActivityBar(): void {
+		const activityBar = mainWindow.document.querySelector('.activitybar');
+		if (activityBar && !activityBar.classList.contains('zaelot-enhanced')) {
+			activityBar.classList.add('zaelot-enhanced');
+
+			// Add Zaelot styling to activity bar items
+			const activityItems = activityBar.querySelectorAll('.action-item');
+			activityItems.forEach(item => {
+				if (!item.classList.contains('zaelot-activity-item')) {
+					item.classList.add('zaelot-activity-item');
+				}
+			});
+		}
+	}
+
+	private _enhanceStatusBar(): void {
+		const statusBar = mainWindow.document.querySelector('.statusbar');
+		if (statusBar && !statusBar.classList.contains('zaelot-enhanced')) {
+			statusBar.classList.add('zaelot-enhanced');
+
+			// Add Claude status indicator
+			this._addClaudeStatusIndicator();
+		}
+	}
+
+	private _addClaudeStatusIndicator(): void {
+		const statusBar = mainWindow.document.querySelector('.statusbar-item.right');
+		if (statusBar) {
+			const claudeIndicator = mainWindow.document.createElement('div');
+			claudeIndicator.className = 'statusbar-item zaelot-claude-status';
+			claudeIndicator.innerHTML = `
+				<span class="zaelot-status-connected">Claude AI Ready</span>
+			`;
+			claudeIndicator.title = 'Claude AI Integration Status';
+
+			// Insert at the beginning of right status bar
+			statusBar.insertBefore(claudeIndicator, statusBar.firstChild);
+		}
+	}
+}
+
+// Register the workbench contribution
+const workbenchRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
+workbenchRegistry.registerWorkbenchContribution(ZaelotWorkbenchContribution, LifecyclePhase.Restored);

--- a/src/vs/workbench/contrib/zaelot/browser/zaelotSplash.ts
+++ b/src/vs/workbench/contrib/zaelot/browser/zaelotSplash.ts
@@ -1,0 +1,262 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../../base/common/lifecycle.js';
+import { IThemeService } from '../../../../platform/theme/common/themeService.js';
+import { IWorkbenchLayoutService } from '../../../services/layout/browser/layoutService.js';
+import { ILifecycleService, LifecyclePhase } from '../../../services/lifecycle/common/lifecycle.js';
+import { ILogService } from '../../../../platform/log/common/log.js';
+import { mainWindow } from '../../../../base/browser/window.js';
+
+export class ZaelotSplashService extends Disposable {
+
+	private static readonly SPLASH_ELEMENT_ID = 'zaelot-splash-screen';
+
+	constructor(
+		@IThemeService private readonly themeService: IThemeService,
+		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
+		@ILifecycleService private readonly lifecycleService: ILifecycleService,
+		@ILogService private readonly logService: ILogService
+	) {
+		super();
+
+		this._createSplashScreen();
+		this._setupRemovalListeners();
+	}
+
+	private _createSplashScreen(): void {
+		const existingSplash = mainWindow.document.getElementById(ZaelotSplashService.SPLASH_ELEMENT_ID);
+		if (existingSplash) {
+			return; // Already exists
+		}
+
+		const splashElement = mainWindow.document.createElement('div');
+		splashElement.id = ZaelotSplashService.SPLASH_ELEMENT_ID;
+		splashElement.className = 'zaelot-splash-container';
+
+		const currentTheme = this.themeService.getColorTheme();
+		const isDark = currentTheme.type === 'dark';
+
+		splashElement.innerHTML = this._getSplashHTML(isDark);
+		splashElement.style.cssText = this._getSplashCSS(isDark);
+
+		// Insert splash screen
+		mainWindow.document.body.appendChild(splashElement);
+
+		this.logService.info('Zaelot splash screen created');
+	}
+
+	private _getSplashHTML(isDark: boolean): string {
+		return `
+			<div class="zaelot-splash-content">
+				<div class="zaelot-splash-logo">
+					<div class="zaelot-logo-circle">
+						<span class="zaelot-logo-text">Z</span>
+					</div>
+				</div>
+				<div class="zaelot-splash-title">
+					<h1>Zaelot Developer Studio</h1>
+					<p>Powered by Claude AI</p>
+				</div>
+				<div class="zaelot-splash-loading">
+					<div class="zaelot-loading-bar">
+						<div class="zaelot-loading-progress"></div>
+					</div>
+					<p class="zaelot-loading-text">Initializing your AI-powered development environment...</p>
+				</div>
+				<div class="zaelot-splash-footer">
+					<p>&copy; 2025 Zaelot Inc. All rights reserved.</p>
+				</div>
+			</div>
+		`;
+	}
+
+	private _getSplashCSS(isDark: boolean): string {
+		const backgroundColor = isDark ? '#1E1E1E' : '#FFFFFF';
+		const textColor = isDark ? '#CCCCCC' : '#333333';
+		const primaryColor = '#007ACC';
+		const secondaryColor = '#0E4B7A';
+		const accentColor = '#00D4FF';
+
+		return `
+			position: fixed;
+			top: 0;
+			left: 0;
+			width: 100vw;
+			height: 100vh;
+			background: linear-gradient(135deg, ${backgroundColor} 0%, ${isDark ? '#252526' : '#F8F9FA'} 100%);
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			z-index: 10000;
+			font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+
+			.zaelot-splash-content {
+				text-align: center;
+				max-width: 400px;
+				padding: 40px;
+			}
+
+			.zaelot-splash-logo {
+				margin-bottom: 30px;
+			}
+
+			.zaelot-logo-circle {
+				width: 80px;
+				height: 80px;
+				background: linear-gradient(135deg, ${primaryColor}, ${secondaryColor});
+				border-radius: 50%;
+				display: inline-flex;
+				align-items: center;
+				justify-content: center;
+				box-shadow: 0 8px 32px rgba(0, 122, 204, 0.3);
+				animation: zaelot-logo-pulse 2s ease-in-out infinite;
+			}
+
+			.zaelot-logo-text {
+				color: white;
+				font-size: 36px;
+				font-weight: 700;
+				letter-spacing: 2px;
+			}
+
+			.zaelot-splash-title h1 {
+				color: ${textColor};
+				font-size: 32px;
+				font-weight: 600;
+				margin: 0 0 8px 0;
+				letter-spacing: -0.5px;
+			}
+
+			.zaelot-splash-title p {
+				color: ${primaryColor};
+				font-size: 16px;
+				font-weight: 500;
+				margin: 0 0 40px 0;
+				opacity: 0.9;
+			}
+
+			.zaelot-splash-loading {
+				margin-bottom: 40px;
+			}
+
+			.zaelot-loading-bar {
+				width: 100%;
+				height: 4px;
+				background: ${isDark ? '#3C3C3C' : '#E0E0E0'};
+				border-radius: 2px;
+				overflow: hidden;
+				margin-bottom: 16px;
+			}
+
+			.zaelot-loading-progress {
+				height: 100%;
+				background: linear-gradient(90deg, ${primaryColor}, ${accentColor});
+				border-radius: 2px;
+				animation: zaelot-loading 2s ease-in-out infinite;
+			}
+
+			.zaelot-loading-text {
+				color: ${textColor};
+				font-size: 14px;
+				margin: 0;
+				opacity: 0.8;
+				animation: zaelot-fade 1.5s ease-in-out infinite;
+			}
+
+			.zaelot-splash-footer {
+				opacity: 0.6;
+			}
+
+			.zaelot-splash-footer p {
+				color: ${textColor};
+				font-size: 12px;
+				margin: 0;
+			}
+
+			@keyframes zaelot-logo-pulse {
+				0%, 100% {
+					transform: scale(1);
+					box-shadow: 0 8px 32px rgba(0, 122, 204, 0.3);
+				}
+				50% {
+					transform: scale(1.05);
+					box-shadow: 0 12px 40px rgba(0, 122, 204, 0.5);
+				}
+			}
+
+			@keyframes zaelot-loading {
+				0% {
+					width: 0%;
+					transform: translateX(-100%);
+				}
+				50% {
+					width: 100%;
+					transform: translateX(0%);
+				}
+				100% {
+					width: 100%;
+					transform: translateX(100%);
+				}
+			}
+
+			@keyframes zaelot-fade {
+				0%, 100% {
+					opacity: 0.8;
+				}
+				50% {
+					opacity: 0.4;
+				}
+			}
+
+			@media (max-width: 768px) {
+				.zaelot-splash-content {
+					padding: 20px;
+				}
+
+				.zaelot-logo-circle {
+					width: 60px;
+					height: 60px;
+				}
+
+				.zaelot-logo-text {
+					font-size: 28px;
+				}
+
+				.zaelot-splash-title h1 {
+					font-size: 24px;
+				}
+			}
+		`;
+	}
+
+	private _setupRemovalListeners(): void {
+		// Remove splash screen when workbench is ready
+		this.lifecycleService.when(LifecyclePhase.Ready).then(() => {
+			setTimeout(() => this._removeSplashScreen(), 1500); // Keep it for a bit to show the animation
+		});
+
+		// Also remove on layout ready as a fallback
+		this._register(this.layoutService.onDidLayoutMainContainer(() => {
+			setTimeout(() => this._removeSplashScreen(), 2000);
+		}));
+	}
+
+	private _removeSplashScreen(): void {
+		const splashElement = mainWindow.document.getElementById(ZaelotSplashService.SPLASH_ELEMENT_ID);
+		if (splashElement) {
+			// Add fade out animation
+			splashElement.style.transition = 'opacity 0.5s ease-out';
+			splashElement.style.opacity = '0';
+
+			setTimeout(() => {
+				if (splashElement.parentNode) {
+					splashElement.parentNode.removeChild(splashElement);
+					this.logService.info('Zaelot splash screen removed');
+				}
+			}, 500);
+		}
+	}
+}

--- a/src/vs/workbench/contrib/zaelot/browser/zaelotTheme.ts
+++ b/src/vs/workbench/contrib/zaelot/browser/zaelotTheme.ts
@@ -1,0 +1,250 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { registerColor, transparent, contrastBorder } from '../../../../platform/theme/common/colorRegistry.js';
+import { Color } from '../../../../base/common/color.js';
+
+// Zaelot Brand Colors
+export const zaelotPrimary = Color.fromHex('#007ACC'); // Zaelot Blue
+export const zaelotSecondary = Color.fromHex('#0E4B7A'); // Darker Blue
+export const zaelotAccent = Color.fromHex('#00D4FF'); // Light Blue
+export const zaelotSuccess = Color.fromHex('#28A745'); // Green
+export const zaelotWarning = Color.fromHex('#FFC107'); // Yellow
+export const zaelotError = Color.fromHex('#DC3545'); // Red
+
+// Register Zaelot-specific colors
+export const zaelotWelcomeBackground = registerColor(
+	'zaelot.welcome.background',
+	{ dark: '#1E1E1E', light: '#F8F9FA', hcDark: '#000000', hcLight: '#FFFFFF' },
+	'Zaelot Developer Studio welcome screen background'
+);
+
+export const zaelotWelcomeForeground = registerColor(
+	'zaelot.welcome.foreground',
+	{ dark: '#CCCCCC', light: '#333333', hcDark: '#FFFFFF', hcLight: '#000000' },
+	'Zaelot Developer Studio welcome screen foreground'
+);
+
+export const zaelotBrandPrimary = registerColor(
+	'zaelot.brand.primary',
+	{ dark: zaelotPrimary, light: zaelotPrimary, hcDark: zaelotAccent, hcLight: zaelotPrimary },
+	'Zaelot primary brand color'
+);
+
+export const zaelotBrandSecondary = registerColor(
+	'zaelot.brand.secondary',
+	{ dark: zaelotSecondary, light: zaelotSecondary, hcDark: zaelotSecondary, hcLight: zaelotSecondary },
+	'Zaelot secondary brand color'
+);
+
+export const zaelotBrandAccent = registerColor(
+	'zaelot.brand.accent',
+	{ dark: zaelotAccent, light: zaelotAccent, hcDark: zaelotAccent, hcLight: zaelotAccent },
+	'Zaelot accent brand color'
+);
+
+export const zaelotChatBackground = registerColor(
+	'zaelot.chat.background',
+	{ dark: '#252526', light: '#F3F3F3', hcDark: '#000000', hcLight: '#FFFFFF' },
+	'Zaelot chat interface background'
+);
+
+export const zaelotChatBorder = registerColor(
+	'zaelot.chat.border',
+	{ dark: zaelotPrimary, light: zaelotPrimary, hcDark: contrastBorder, hcLight: contrastBorder },
+	'Zaelot chat interface border'
+);
+
+export const zaelotButtonBackground = registerColor(
+	'zaelot.button.background',
+	{ dark: zaelotPrimary, light: zaelotPrimary, hcDark: zaelotPrimary, hcLight: zaelotPrimary },
+	'Zaelot button background'
+);
+
+export const zaelotButtonForeground = registerColor(
+	'zaelot.button.foreground',
+	{ dark: '#FFFFFF', light: '#FFFFFF', hcDark: '#FFFFFF', hcLight: '#FFFFFF' },
+	'Zaelot button foreground'
+);
+
+export const zaelotButtonHoverBackground = registerColor(
+	'zaelot.button.hoverBackground',
+	{ dark: zaelotSecondary, light: zaelotSecondary, hcDark: zaelotSecondary, hcLight: zaelotSecondary },
+	'Zaelot button hover background'
+);
+
+export const zaelotStatusBarBackground = registerColor(
+	'zaelot.statusBar.background',
+	{ dark: zaelotSecondary, light: zaelotPrimary, hcDark: zaelotSecondary, hcLight: zaelotPrimary },
+	'Zaelot status bar background'
+);
+
+export const zaelotActivityBarBackground = registerColor(
+	'zaelot.activityBar.background',
+	{ dark: '#2C2C2C', light: '#2C2C2C', hcDark: '#000000', hcLight: '#FFFFFF' },
+	'Zaelot activity bar background'
+);
+
+export const zaelotTabActiveBackground = registerColor(
+	'zaelot.tab.activeBackground',
+	{ dark: '#1E1E1E', light: '#FFFFFF', hcDark: '#000000', hcLight: '#FFFFFF' },
+	'Zaelot active tab background'
+);
+
+export const zaelotTabActiveBorder = registerColor(
+	'zaelot.tab.activeBorder',
+	{ dark: zaelotPrimary, light: zaelotPrimary, hcDark: zaelotAccent, hcLight: zaelotPrimary },
+	'Zaelot active tab border'
+);
+
+export const zaelotNotificationBackground = registerColor(
+	'zaelot.notification.background',
+	{ dark: '#383838', light: '#F8F9FA', hcDark: '#000000', hcLight: '#FFFFFF' },
+	'Zaelot notification background'
+);
+
+export const zaelotNotificationBorder = registerColor(
+	'zaelot.notification.border',
+	{ dark: zaelotPrimary, light: zaelotPrimary, hcDark: contrastBorder, hcLight: contrastBorder },
+	'Zaelot notification border'
+);
+
+export const zaelotSidebarBackground = registerColor(
+	'zaelot.sidebar.background',
+	{ dark: '#252526', light: '#F3F3F3', hcDark: '#000000', hcLight: '#FFFFFF' },
+	'Zaelot sidebar background'
+);
+
+export const zaelotEditorBackground = registerColor(
+	'zaelot.editor.background',
+	{ dark: '#1E1E1E', light: '#FFFFFF', hcDark: '#000000', hcLight: '#FFFFFF' },
+	'Zaelot editor background'
+);
+
+export const zaelotMenuBackground = registerColor(
+	'zaelot.menu.background',
+	{ dark: '#383838', light: '#F8F9FA', hcDark: '#000000', hcLight: '#FFFFFF' },
+	'Zaelot menu background'
+);
+
+export const zaelotMenuBorder = registerColor(
+	'zaelot.menu.border',
+	{ dark: zaelotPrimary, light: zaelotPrimary, hcDark: contrastBorder, hcLight: contrastBorder },
+	'Zaelot menu border'
+);
+
+export const zaelotTitleBarBackground = registerColor(
+	'zaelot.titleBar.background',
+	{ dark: zaelotSecondary, light: zaelotPrimary, hcDark: zaelotSecondary, hcLight: zaelotPrimary },
+	'Zaelot title bar background'
+);
+
+export const zaelotTitleBarForeground = registerColor(
+	'zaelot.titleBar.foreground',
+	{ dark: '#FFFFFF', light: '#FFFFFF', hcDark: '#FFFFFF', hcLight: '#FFFFFF' },
+	'Zaelot title bar foreground'
+);
+
+export const zaelotProgressBarBackground = registerColor(
+	'zaelot.progressBar.background',
+	{ dark: zaelotPrimary, light: zaelotPrimary, hcDark: zaelotAccent, hcLight: zaelotPrimary },
+	'Zaelot progress bar background'
+);
+
+export const zaelotLinkForeground = registerColor(
+	'zaelot.link.foreground',
+	{ dark: zaelotAccent, light: zaelotPrimary, hcDark: zaelotAccent, hcLight: zaelotPrimary },
+	'Zaelot link foreground'
+);
+
+export const zaelotLinkHoverForeground = registerColor(
+	'zaelot.link.hoverForeground',
+	{ dark: '#FFFFFF', light: zaelotSecondary, hcDark: '#FFFFFF', hcLight: zaelotSecondary },
+	'Zaelot link hover foreground'
+);
+
+export const zaelotBadgeBackground = registerColor(
+	'zaelot.badge.background',
+	{ dark: zaelotPrimary, light: zaelotPrimary, hcDark: zaelotPrimary, hcLight: zaelotPrimary },
+	'Zaelot badge background'
+);
+
+export const zaelotBadgeForeground = registerColor(
+	'zaelot.badge.foreground',
+	{ dark: '#FFFFFF', light: '#FFFFFF', hcDark: '#FFFFFF', hcLight: '#FFFFFF' },
+	'Zaelot badge foreground'
+);
+
+export const zaelotScrollbarSliderBackground = registerColor(
+	'zaelot.scrollbarSlider.background',
+	{ dark: transparent(zaelotPrimary, 0.3), light: transparent(zaelotPrimary, 0.3), hcDark: transparent(zaelotAccent, 0.3), hcLight: transparent(zaelotPrimary, 0.3) },
+	'Zaelot scrollbar slider background'
+);
+
+export const zaelotScrollbarSliderHoverBackground = registerColor(
+	'zaelot.scrollbarSlider.hoverBackground',
+	{ dark: transparent(zaelotPrimary, 0.5), light: transparent(zaelotPrimary, 0.5), hcDark: transparent(zaelotAccent, 0.5), hcLight: transparent(zaelotPrimary, 0.5) },
+	'Zaelot scrollbar slider hover background'
+);
+
+export const zaelotScrollbarSliderActiveBackground = registerColor(
+	'zaelot.scrollbarSlider.activeBackground',
+	{ dark: transparent(zaelotPrimary, 0.7), light: transparent(zaelotPrimary, 0.7), hcDark: transparent(zaelotAccent, 0.7), hcLight: transparent(zaelotPrimary, 0.7) },
+	'Zaelot scrollbar slider active background'
+);
+
+export const zaelotInputBackground = registerColor(
+	'zaelot.input.background',
+	{ dark: '#3C3C3C', light: '#FFFFFF', hcDark: '#000000', hcLight: '#FFFFFF' },
+	'Zaelot input background'
+);
+
+export const zaelotInputBorder = registerColor(
+	'zaelot.input.border',
+	{ dark: zaelotPrimary, light: zaelotPrimary, hcDark: contrastBorder, hcLight: contrastBorder },
+	'Zaelot input border'
+);
+
+export const zaelotInputFocusBorder = registerColor(
+	'zaelot.input.focusBorder',
+	{ dark: zaelotAccent, light: zaelotAccent, hcDark: zaelotAccent, hcLight: zaelotAccent },
+	'Zaelot input focus border'
+);
+
+export const zaelotDropdownBackground = registerColor(
+	'zaelot.dropdown.background',
+	{ dark: '#383838', light: '#F8F9FA', hcDark: '#000000', hcLight: '#FFFFFF' },
+	'Zaelot dropdown background'
+);
+
+export const zaelotDropdownBorder = registerColor(
+	'zaelot.dropdown.border',
+	{ dark: zaelotPrimary, light: zaelotPrimary, hcDark: contrastBorder, hcLight: contrastBorder },
+	'Zaelot dropdown border'
+);
+
+export const zaelotListActiveSelectionBackground = registerColor(
+	'zaelot.list.activeSelectionBackground',
+	{ dark: zaelotPrimary, light: zaelotPrimary, hcDark: zaelotPrimary, hcLight: zaelotPrimary },
+	'Zaelot list active selection background'
+);
+
+export const zaelotListActiveSelectionForeground = registerColor(
+	'zaelot.list.activeSelectionForeground',
+	{ dark: '#FFFFFF', light: '#FFFFFF', hcDark: '#FFFFFF', hcLight: '#FFFFFF' },
+	'Zaelot list active selection foreground'
+);
+
+export const zaelotListHoverBackground = registerColor(
+	'zaelot.list.hoverBackground',
+	{ dark: transparent(zaelotPrimary, 0.2), light: transparent(zaelotPrimary, 0.2), hcDark: transparent(zaelotAccent, 0.2), hcLight: transparent(zaelotPrimary, 0.2) },
+	'Zaelot list hover background'
+);
+
+export const zaelotTreeIndentGuidesStroke = registerColor(
+	'zaelot.tree.indentGuidesStroke',
+	{ dark: zaelotPrimary, light: zaelotPrimary, hcDark: zaelotAccent, hcLight: zaelotPrimary },
+	'Zaelot tree indent guides stroke'
+);

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -209,6 +209,9 @@ import './contrib/inlineChat/browser/inlineChat.contribution.js';
 import './contrib/mcp/browser/mcp.contribution.js';
 import './contrib/claude/browser/claude.contribution.js';
 
+// Zaelot Branding
+import './contrib/zaelot/browser/zaelot.contribution.js';
+
 // Interactive
 import './contrib/interactive/browser/interactive.contribution.js';
 


### PR DESCRIPTION
- Remove all VSCode references and replace with 'Zaelot Developer Studio'
- Add custom Zaelot theme with brand colors and styling
- Implement custom splash screen with animations
- Enhance welcome page with Zaelot-specific content and messaging
- Update getting started content to highlight Claude AI integration
- Add comprehensive branding across the application

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
